### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/src/main/java/uk/ac/vfb/geppetto/AddImportTypesSynonymQueryProcessor.java
+++ b/src/main/java/uk/ac/vfb/geppetto/AddImportTypesSynonymQueryProcessor.java
@@ -147,7 +147,7 @@ public class AddImportTypesSynonymQueryProcessor extends AQueryProcessor
 							}
 							if(results.getValue("relDOI", i) != null)
 							{
-								synonymLinks += " <a href=\" http://dx.doi.org/" + (String) results.getValue("relDOI", i) + "\" target=\"_blank\" >"
+								synonymLinks += " <a href=\" https://doi.org/" + (String) results.getValue("relDOI", i) + "\" target=\"_blank\" >"
 										+ "<i class=\"popup-icon-link gpt-doi\" title=\"doi:" + (String) results.getValue("relDOI", i) + "\" aria-hidden=\"true\"></i></a>";
 							}
 
@@ -174,7 +174,7 @@ public class AddImportTypesSynonymQueryProcessor extends AQueryProcessor
 								}
 								if(results.getValue("relDOI", i) != null)
 								{
-									defRefs += " <a href=\" http://dx.doi.org/" + (String) results.getValue("relDOI", i) + "\" target=\"_blank\" >"
+									defRefs += " <a href=\" https://doi.org/" + (String) results.getValue("relDOI", i) + "\" target=\"_blank\" >"
 											+ "<i class=\"popup-icon-link gpt-doi\" title=\"doi:" + (String) results.getValue("relDOI", i) + "\" aria-hidden=\"true\"></i></a>";
 								}
 								defRefs += "<br/>";
@@ -222,7 +222,7 @@ public class AddImportTypesSynonymQueryProcessor extends AQueryProcessor
 									}
 									if(results.getValue("relDOI", i) != null)
 									{
-										relat += " <a href=\" http://dx.doi.org/" + (String) results.getValue("relDOI", i) + "\" target=\"_blank\" >"
+										relat += " <a href=\" https://doi.org/" + (String) results.getValue("relDOI", i) + "\" target=\"_blank\" >"
 												+ "<i class=\"popup-icon-link gpt-doi\" title=\"doi:" + (String) results.getValue("relDOI", i) + "\" aria-hidden=\"true\"></i>";
 									}
 								}

--- a/src/main/java/uk/ac/vfb/geppetto/VFBProcessTermInfo.java
+++ b/src/main/java/uk/ac/vfb/geppetto/VFBProcessTermInfo.java
@@ -340,7 +340,7 @@ public class VFBProcessTermInfo extends AQueryProcessor {
                                                 }
                                                 if(((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) != null)
                                                 {
-                                                    edgeLabel += " <a href=\"http://dx.doi.org/" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" target=\"_blank\" >"
+                                                    edgeLabel += " <a href=\"https://doi.org/" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" target=\"_blank\" >"
                                                             + "<i class=\"popup-icon-link gpt-doi\" title=\"doi:" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" aria-hidden=\"true\"></i></a>";
                                                 }
                                                 for (int s = 0; s < synonyms.size(); s++) {
@@ -397,7 +397,7 @@ public class VFBProcessTermInfo extends AQueryProcessor {
                                                 }
                                                 if(((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) != null)
                                                 {
-                                                    edgeLabel += " <a href=\"http://dx.doi.org/" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" target=\"_blank\" >"
+                                                    edgeLabel += " <a href=\"https://doi.org/" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" target=\"_blank\" >"
                                                             + "<i class=\"popup-icon-link gpt-doi\" title=\"doi:" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" aria-hidden=\"true\"></i></a>";
                                                 }
                                                 if (((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).containsKey("label")) {
@@ -443,7 +443,7 @@ public class VFBProcessTermInfo extends AQueryProcessor {
                                                 }
                                                 if(((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) != null)
                                                 {
-                                                    edgeLabel += " <a href=\"http://dx.doi.org/" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" target=\"_blank\" >"
+                                                    edgeLabel += " <a href=\"https://doi.org/" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" target=\"_blank\" >"
                                                             + "<i class=\"popup-icon-link gpt-doi\" title=\"doi:" + ((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("DOI")) + "\" aria-hidden=\"true\"></i></a>";
                                                 }
                                             }else if (((String) ((Map<String, String>) ((Map<String, Object>) resultLinks.get(i)).get("to")).get("http")) != null) {


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update any code that generates new DOI links.

Cheers!