### PR TITLE
single quotes replaced by double due to error triggered by neo4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>uk.ac</groupId>
 	<artifactId>vfb.geppetto</artifactId>
 	<name>VFB Geppetto Data Sources</name>
-	<version>0.4.2</version>
+	<version>1.0.0</version>
 	<packaging>bundle</packaging>
 	<properties>
 		<spring.version>4.3.9.RELEASE</spring.version>

--- a/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor.java
+++ b/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor.java
@@ -73,7 +73,7 @@ public class OWLeryQueryProcessor extends AQueryProcessor
 					SerializableQueryResult processedResult = DatasourcesFactory.eINSTANCE.createSerializableQueryResult();
 					String subID = id.substring((id.lastIndexOf('/')+1) , id.length()).toString();
 					processedResult.getValues().add(subID);
-					ids.add("'" + subID + "'");
+					ids.add("\"" + subID + "\"");
 					processedResults.getResults().add(processedResult);
 				}
 			}

--- a/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor1.java
+++ b/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor1.java
@@ -73,7 +73,7 @@ public class OWLeryQueryProcessor1 extends AQueryProcessor
 				System.out.println(idsList);
 				for(String id : idsList) {
 					String subID = id.substring((id.lastIndexOf('/')+1) , id.length()).toString();
-					ids.add("'" + subID + "'");
+					ids.add("\"" + subID + "\"");
 				}
 			}
 		}

--- a/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor2.java
+++ b/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor2.java
@@ -72,7 +72,7 @@ public class OWLeryQueryProcessor2 extends AQueryProcessor
 				List<String> idsList = (ArrayList)((QueryResult) result).getValues().get(idIndex);
 				for(String id : idsList) {
 					String subID = id.substring((id.lastIndexOf('/')+1) , id.length()).toString();
-					ids.add("'" + subID + "'");
+					ids.add("\"" + subID + "\"");
 				}
 			}
 		}

--- a/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor3.java
+++ b/src/main/java/uk/ac/vfb/geppetto/OWLeryQueryProcessor3.java
@@ -88,7 +88,7 @@ public class OWLeryQueryProcessor3 extends AQueryProcessor
 				List<String> idsList = (ArrayList)((QueryResult) result).getValues().get(idIndex);
 				for(String id : idsList) {
 					String subID = id.substring((id.lastIndexOf('/')+1) , id.length()).toString();
-					ids.add("'" + subID + "'");
+					ids.add("\"" + subID + "\"");
 				}
 			}
 		}


### PR DESCRIPTION
part of [this](https://github.com/VirtualFlyBrain/geppetto-vfb/pull/344) and [this](https://github.com/openworm/org.geppetto.datasources/pull/33) .
Changes are simple, just replacing the single quote with the double due to an issue with neo4j that does not like the previous struct.